### PR TITLE
Enable pdflatex+hyperref to generate ToC-metadata

### DIFF
--- a/latex/acl.sty
+++ b/latex/acl.sty
@@ -112,10 +112,6 @@
 
 \twocolumn \sloppy
 
-% We're never going to need a table of contents, so just flush it to
-% save space --- suggested by drstrip@sandia-2
-\def\addcontentsline#1#2#3{}
-
 \ifacl@finalcopy
     \thispagestyle{empty}        
     \pagestyle{empty}


### PR DESCRIPTION
The style file was configured so that LaTeX would not to generate a table of contents. It was stated that this is “never going to [be] need[ed].” This configuration has been part of the ACL style files since, at least, [ACL 2000](https://cse.hkust.edu.hk/acl2000/Latex/aclsub.sty).

I do not agree that the table of contents is not needed. While it may be true that a table of contents will never be printed on the first page of an ACL-paper, these lines also prevent `hyperref` from generating the toc-metadata that PDF-viewers use to show an electronic table of content for navigating the PDF, a feature that I find immensely useful.

This pull request deletes these three lines from the style file and re-enables the generation of ToC metadata