### PR TITLE
Add possessive cite

### DIFF
--- a/latex/acl.sty
+++ b/latex/acl.sty
@@ -191,13 +191,26 @@
 \captionsetup{font=10pt}
 
 \RequirePackage{natbib}
+\RequirePackage{xstring}
+\RequirePackage{etoolbox}
 % for citation commands in the .tex, authors can use:
 % \citep, \citet, and \citeyearpar for compatibility with natbib, or
 % \cite, \newcite, and \shortcite for compatibility with older ACL .sty files
 \renewcommand\cite{\citep}	% to get "(Author Year)" with natbib    
 \newcommand\shortcite{\citeyearpar}% to get "(Year)" with natbib    
 \newcommand\newcite{\citet}	% to get "Author (Year)" with natbib
-\newcommand{\citeposs}[1]{\citeauthor{#1}'s (\citeyear{#1})} % to get "Author's (Year)"
+\DeclareRobustCommand\citepos   % to get "Author' (Year)", "Author's (Year)", and "Author et al.'s (Year)" with natbib
+  {\begingroup
+   \let\NAT@nmfmt\NAT@posfmt% ...except with a different name format
+   \NAT@swafalse\let\NAT@ctype\z@\NAT@partrue
+   \@ifstar{\NAT@fulltrue\NAT@citetp}{\NAT@fullfalse\NAT@citetp}}
+
+\let\NAT@orig@nmfmt\NAT@nmfmt
+\def\NAT@posfmt#1{%
+  \StrRemoveBraces{#1}[\NAT@temp]%
+  \IfEndWith{\NAT@temp}{s}
+    {\NAT@orig@nmfmt{#1'}}
+    {\NAT@orig@nmfmt{#1's}}}
 
 \bibliographystyle{acl_natbib}
 


### PR DESCRIPTION
Adds a command for possessive citations. Examples:

\citeauthor{Adams_2019}' \citeyear{Adams_2019} -> \citepos{Adams_2019}: Adams' (2019)
\citeauthor{Adams_et_al_2019}'s \citeyear{Adams_et_al_2019} -> \citepos{Adams_et_al_2019}: Adams et al.'s (2019)
\citeauthor{Ma_2019}' \citeyear{Ma_2019} -> \citepos{Ma_2019}: Ma's (2019)

Just to fix a little annoyance of mine.