### PR TITLE
Add basic "Limitations" section information

### DIFF
--- a/latex/acl_latex.tex
+++ b/latex/acl_latex.tex
@@ -331,7 +331,7 @@ If a Bib\TeX{} entry has a URL or DOI field, the paper title in the references s
 
 \section*{Limitations}
 
-Since December 2023, a limitations section (titled "Limitations" and numbered) has been required for all papers. This section should be placed at the end of the paper, before the references. The "Limitations" section (along with, optionally, a section for ethical considerations) may be up to one page and will not count toward the final page limit.
+Since December 2023, a "Limitations" section has been required for all papers. This section should be placed at the end of the paper, before the references. The "Limitations" section (along with, optionally, a section for ethical considerations) may be up to one page and will not count toward the final page limit.
 
 \section*{Acknowledgments}
 

--- a/latex/acl_latex.tex
+++ b/latex/acl_latex.tex
@@ -331,7 +331,7 @@ If a Bib\TeX{} entry has a URL or DOI field, the paper title in the references s
 
 \section*{Limitations}
 
-Since December 2023, a "Limitations" section has been required for all papers. This section should be placed at the end of the paper, before the references. The "Limitations" section (along with, optionally, a section for ethical considerations) may be up to one page and will not count toward the final page limit.
+Since December 2023, a "Limitations" section has been required for all papers submitted to ACL Rolling Review (ARR). This section should be placed at the end of the paper, before the references. The "Limitations" section (along with, optionally, a section for ethical considerations) may be up to one page and will not count toward the final page limit. Note that these files may be used by venues that do not rely on ARR so it is recommended to verify the requirement of a "Limitations" section and other criteria with the venue in question.
 
 \section*{Acknowledgments}
 

--- a/latex/acl_latex.tex
+++ b/latex/acl_latex.tex
@@ -329,6 +329,10 @@ Please ensure that Bib\TeX{} records contain DOIs or URLs when possible, and for
 Use the \verb|doi| field for DOIs and the \verb|url| field for URLs.
 If a Bib\TeX{} entry has a URL or DOI field, the paper title in the references section will appear as a hyperlink to the paper, using the hyperref \LaTeX{} package.
 
+\section{Limitations}
+
+Since December 2023, a limitations section (titled "Limitations" and numbered) has been required for all papers. This section should be placed at the end of the paper, before any acknowledgments. The "Limitations" section (along with, optionally, a section for ethical considerations) may be up to one page and will not count toward the final page limit.
+
 \section*{Acknowledgments}
 
 This document has been adapted

--- a/latex/acl_latex.tex
+++ b/latex/acl_latex.tex
@@ -331,7 +331,7 @@ If a Bib\TeX{} entry has a URL or DOI field, the paper title in the references s
 
 \section{Limitations}
 
-Since December 2023, a limitations section (titled "Limitations" and numbered) has been required for all papers. This section should be placed at the end of the paper, before any acknowledgments. The "Limitations" section (along with, optionally, a section for ethical considerations) may be up to one page and will not count toward the final page limit.
+Since December 2023, a limitations section (titled "Limitations" and numbered) has been required for all papers. This section should be placed at the end of the paper, before the references. The "Limitations" section (along with, optionally, a section for ethical considerations) may be up to one page and will not count toward the final page limit.
 
 \section*{Acknowledgments}
 

--- a/latex/acl_latex.tex
+++ b/latex/acl_latex.tex
@@ -329,7 +329,7 @@ Please ensure that Bib\TeX{} records contain DOIs or URLs when possible, and for
 Use the \verb|doi| field for DOIs and the \verb|url| field for URLs.
 If a Bib\TeX{} entry has a URL or DOI field, the paper title in the references section will appear as a hyperlink to the paper, using the hyperref \LaTeX{} package.
 
-\section{Limitations}
+\section*{Limitations}
 
 Since December 2023, a limitations section (titled "Limitations" and numbered) has been required for all papers. This section should be placed at the end of the paper, before the references. The "Limitations" section (along with, optionally, a section for ethical considerations) may be up to one page and will not count toward the final page limit.
 


### PR DESCRIPTION
Per the [ACL Rolling Review page](https://aclrollingreview.org/cfp), a "Limitations" section is now required. As noted in https://github.com/acl-org/acl-style-files/issues/39, the exclusion of a required section in the example LaTeX files can be a bit confusing. I do recognize that this has been discussed before (see https://github.com/acl-org/acl-style-files/pull/18#issuecomment-1714325873) and has been excluded to distinguish between style and content guidelines. Since the "Limitations" section is now mandatory and has specific requirements (e.g., placement: "at the end of the paper, before the references"; verbiage: 'titled “Limitations”'; length: "up to one page"), I would argue that (at the very least) placement information and section title specification could be considered style guidelines. I've included a small amount of additional information which could certainly be trimmed down the barebones stylistic requirements. Just wanted to bring this back up for discussion.