### PR TITLE
Fix luatex lineno/babel \par interaction bug

### DIFF
--- a/latex/acl.sty
+++ b/latex/acl.sty
@@ -52,7 +52,7 @@
     \loop\ifnum\cv@tmpc<#1\relax0\advance\cv@tmpc1\relax\fi \ifnum\cv@tmpc<#1 \repeat
     \cv@tmpc@=#2\relax\ifnum\cv@tmpc@<0\cv@tmpc@=-\cv@tmpc@\fi \relax\the\cv@tmpc@}%
   \renewcommand\thelinenumber{\fillzeros[3]{\arabic{linenumber}}}
-  \linenumbers
+  \AtBeginDocument{\linenumbers}
 
   \setlength{\linenumbersep}{1.6cm}
 


### PR DESCRIPTION
This fix a bug occurring in both texlive 2023 and 2024 when trying to compile the acl template using luatex (`acl_lualatex.tex`) with line numbers (i.e. in `[review]` mode).
Note that the bug occurs in Overleaf but their interface do not catch it: everything is compiled in "batchmode" (errors are non-stopping) and their log-parser fails to recognise the lua error as an error, hence the absence of the red square thingy. However if you look at the log or try to compile in the outside-of-overleaf-default "errorstopmode" (on Overleaf click on the arrow right of "Recompile" and select "Stop on first error") you'll see that an error is indeed present.

The error comes from the following interaction:
- the `lineno` package redefines `\par` as `\linenumberpar` to do line-numbering
- the `babel` package has some lua-exclusive functionality written in `\directlua` containing empty lines, those empty lines call the `\linenumberpar` of the `lineno` package which (unsurprisingly) expand to invalid lua code.

Redefining `\par` in such a finicky way looks like a bad idea and is certainly the source of more errors, I think the best course of action is to delay this re-definition as much as possible by putting it inside `\AtBeginDocument` which is what this pull request is doing. If someone still has errors with `\par` re-definition in their document, I would advice them to surround the source of the errors with `\nolinenumbers` and `\linenumbers` to temporarily restore the default latex `\par` (and `\@@par`/`\@par`).

For context the babel-code which fails as the result of this error has to do with script-based language identification and automatic font-switching. This is fixed by this pull request.