### PR TITLE
Patch acl_natbib.bst to, when citing papers with co-first authors, mention explicitly the first two in \cite commands

### DIFF
--- a/latex/acl_natbib.bst
+++ b/latex/acl_natbib.bst
@@ -1651,28 +1651,98 @@ FUNCTION {chop.word}
     's
   if$
 }
-FUNCTION {format.lab.names}
-{ 's :=
-  "" 't :=
-  s #1 "{vv~}{ll}" format.name$
-  s num.names$ duplicate$
-  #2 >
-    { pop$
-      " " * bbl.etal *
-    }
-    { #2 <
-        'skip$
-        { s #2 "{ff }{vv }{ll}{ jj}" format.name$ "others" =
-            {
-              " " * bbl.etal *
-            }
-            { bbl.and space.word * s #2 "{vv~}{ll}" format.name$
-              * }
-          if$
-        }
-      if$
-    }
+FUNCTION {string.length.manual}
+{ 
+  's :=           % save input string in variable s
+  #0              % initialize counter to 0
+  {               % begin loop
+    s empty$      % check if s is empty string
+    not           % continue if NOT empty
+  }
+  {               % while true:
+    s #2 global.max$ substring$ 's :=    % remove first character from s
+    #1 +          % increment counter by 1
+  }
+  while$
+}
+STRINGS{mynametest}
+INTEGERS{mynamelength}
+FUNCTION {check.if.starred}
+{
+  'mynametest :=
+  mynametest string.length.manual 'mynamelength :=
+  
+  mynamelength #3 <
+  { mynametest "$^*$" = }
+  { 
+      mynametest mynamelength #3 - mynamelength substring$
+      "$^*$" = 
+  }
   if$
+}
+FUNCTION {strip.star}
+{
+  'mynametest :=
+  mynametest string.length.manual 'mynamelength :=
+
+  mynametest check.if.starred
+  {mynametest #1 mynamelength #4 - substring$}
+  {mynametest}
+  if$
+}
+STRINGS{firstauthor.formattedname}
+STRINGS{secondauthor.formattedname}
+STRINGS{secondauthor.fullname}
+INTEGERS{numauthors}
+FUNCTION {format.lab.names}
+{
+    % Save authors
+    's :=
+    s #1 "{vv~}{ll}" format.name$ 'firstauthor.formattedname :=
+    s num.names$ 'numauthors :=
+    numauthors #2 <
+    {skip$}
+    {
+        s #2 "{vv~}{ll}" format.name$ 'secondauthor.formattedname :=
+        s #2 "{ff }{vv }{ll}{ jj}" format.name$ 'secondauthor.fullname := 
+    }
+    if$
+
+    % Add first author name to stack for printing
+    firstauthor.formattedname strip.star
+
+    % If more than two authors
+    numauthors #2 >
+    {
+        firstauthor.formattedname check.if.starred
+        {
+            ", " *
+            secondauthor.formattedname strip.star *
+            "," *
+        }
+        { 
+            skip$
+        }
+        if$
+        " " * bbl.etal * 
+    }
+    {
+        numauthors #2 <
+        { skip$ }
+        {
+            secondauthor.fullname "others" =
+            {
+                " " * bbl.etal *
+            }
+            { 
+                bbl.and space.word *
+                secondauthor.formattedname strip.star * 
+            }
+            if$
+        }
+        if$
+    }
+    if$
 }
 
 FUNCTION {author.key.label}

--- a/latex/acl_natbib.bst
+++ b/latex/acl_natbib.bst
@@ -1666,29 +1666,29 @@ FUNCTION {string.length.manual}
   }
   while$
 }
-STRINGS{mynametest}
-INTEGERS{mynamelength}
+STRINGS{check.if.starred.name}
+INTEGERS{check.if.starred.namelength}
 FUNCTION {check.if.starred}
 {
-  'mynametest :=
-  mynametest string.length.manual 'mynamelength :=
+  'check.if.starred.name :=
+  check.if.starred.name string.length.manual 'check.if.starred.namelength :=
   
-  mynamelength #3 <
-  { mynametest "$^*$" = }
+  check.if.starred.namelength #3 <
+  { check.if.starred.name "$^*$" = }
   { 
-      mynametest mynamelength #3 - mynamelength substring$
+      check.if.starred.name check.if.starred.namelength #3 - check.if.starred.namelength substring$
       "$^*$" = 
   }
   if$
 }
 FUNCTION {strip.star}
 {
-  'mynametest :=
-  mynametest string.length.manual 'mynamelength :=
+  'check.if.starred.name :=
+  check.if.starred.name string.length.manual 'check.if.starred.namelength :=
 
-  mynametest check.if.starred
-  {mynametest #1 mynamelength #4 - substring$}
-  {mynametest}
+  check.if.starred.name check.if.starred
+  {check.if.starred.name #1 check.if.starred.namelength #4 - substring$}
+  {check.if.starred.name}
   if$
 }
 STRINGS{firstauthor.formattedname}

--- a/latex/acl_natbib.bst
+++ b/latex/acl_natbib.bst
@@ -65,6 +65,7 @@
  %---------------------------------------------------------------------
 
 %% 2025 modified to truncate author lists of more than 20 authors
+%% 2025 modified to explicitly cite the first two co-first authors
 
 ENTRY
   { address


### PR DESCRIPTION
This PR patches the `.bst` file to handle co-first authors.

I'll use the following paper as an example, which has Tiago and Naomi as co-first authors:
```
@inproceedings{pimentel-etal-2020-pareto,
    title = "{P}areto Probing: {T}rading Off Accuracy for Complexity",
    author = "Pimentel, Tiago  and
      Saphra, Naomi  and
      Williams, Adina  and
      Cotterell, Ryan",
    editor = "Webber, Bonnie  and
      Cohn, Trevor  and
      He, Yulan  and
      Liu, Yang",
    booktitle = "Proceedings of the 2020 Conference on Empirical Methods in Natural Language Processing (EMNLP)",
    month = nov,
    year = "2020",
    address = "Online",
    publisher = "Association for Computational Linguistics",
    url = "https://aclanthology.org/2020.emnlp-main.254/",
    doi = "10.18653/v1/2020.emnlp-main.254",
    pages = "3138--3153",
}
```

The current reference entry for this paper is:
>  Tiago Pimentel, Naomi Saphra, Adina Williams, and Ryan Cotterell. 2020. [Pareto Probing: Trading Off Accuracy for Complexity](https://aclanthology.org/2020.emnlp-main.254/). In Proceedings of the 2020 Conference on Empirical Methods in Natural Language Processing (EMNLP), pages 3138–3153, Online. Association for Computational Linguistics.

and an in-text citation would be `(Pimentel et al., 2020)`.

This patch allows someone to add $^*$ to the author's entries in the bibtex, as in:
```
author = "Pimentel$^*$, Tiago  and
      Saphra$^*$, Naomi  and
      Williams, Adina  and
      Cotterell, Ryan",
```
and get the reference entry as:
>  Tiago Pimentel*, Naomi Saphra*, Adina Williams, and Ryan Cotterell. 2020. [Pareto Probing: Trading Off Accuracy for Complexity](https://aclanthology.org/2020.emnlp-main.254/). In Proceedings of the 2020 Conference on Empirical Methods in Natural Language Processing (EMNLP), pages 3138–3153, Online. Association for Computational Linguistics.

paired with the in-text citation: `(Pimentel, Saphra, et al., 2020)`.

As a few examples of how citations look:
<img width="545" alt="image" src="https://github.com/user-attachments/assets/1a1dbb34-3bb7-495c-8a75-23263b2a0c79" />
