### PR TITLE
Added `bidi` for R2L scripts

### DIFF
--- a/latex/acl_lualatex.tex
+++ b/latex/acl_lualatex.tex
@@ -18,7 +18,7 @@
 
 % These font selection commands work with
 % LuaLaTeX and XeLaTeX, but not pdfLaTeX.
-\usepackage[english]{babel} % English as the main language
+\usepackage[english,bidi=default]{babel} % English as the main language.
 \babelfont{rm}{TeX Gyre Termes} % similar to Times
 %%% include whatever languages you need below this line
 \babelprovide[import]{hindi}


### PR DESCRIPTION
 Bidirectional (bidi) needs to be imported for R2L languages. Without it the Arabic text in the example is displayed in the wrong order: Left to Right.