### PR TITLE
Add a workshop template

### DIFF
--- a/acl_workshops.tex
+++ b/acl_workshops.tex
@@ -1,0 +1,35 @@
+\section{Workshop Topic and Content}
+The title of this document should be the work- shop’s title.\\
+In this overview section, give a brief description of the workshop topic and content.
+
+\paragraph{Tagline:} \textit{A very brief advertisement or tagline for the workshop, up to 140 characters, that highlights any key information you wish prospective attendees to know}
+
+\section{Invited Speakers}
+\begin{itemize}
+  \item A list of invited speakers, if applicable, with an indication of which ones have already agreed and which are indicative, and sources of funding for the speakers.
+\end{itemize}
+
+\section{Workshop Size / Prior Events}
+\begin{itemize}
+  %\item An estimate of the number of attendees.
+  \item If the workshop has been held before, a note specifying where previous workshops were held, how many submissions the workshop received, how many papers were accepted (also specify if they were not regular papers, e.g. shared task system description papers, non-archival papers), and how many attendees the workshop attracted.
+  \item A description of special requirements and technical needs.
+  \item Workshop duration (1 / 2 day(s)).
+\end{itemize}
+
+\section{Shared Tasks (if any)}
+\begin{itemize}
+  \item A description of any shared tasks associated with the workshop, and estimate of the number of participants.
+\end{itemize}
+
+\paragraph{Preferred Venue:} The preferred venue(s) (EACL / ACL / NAACL / EMNLP), if any, and description of any constraints (e.g., if the workshop is compatible with only one of these events, logistically, thematically or otherwise)
+
+\section{Diversity and Inclusion}
+The proposals should describe potential ways in which the workshop will support diversity in NLP. We suggest organizers consider the following points, while developing the proposal:
+
+\paragraph{Contribution to academic diversity:} The proposals could explain how the subject matter of the workshop will contribute to the diversity of the field, e.g. use of multilingual data, indications of how the described methods scale up to various languages or domains, accessibility of resources, supporting underrepresented communities of NLP and so on.
+
+\paragraph{Diversifying representation:} Following the \href{https://winlp.org}{WiNLP} initiative, we recognize the current problems of demographic imbalance in the field. Therefore, we particularly encourage submissions including members of under-represented groups in computational linguistics. The proposals should describe how their selection of invited speakers, panelists, organizers, and program committee promotes diverse representation (for example, considering underrepresented demographics based on gender, ethnicity, nationality, and so on). We also suggest including speakers and panelists, who have not appeared as a keynote speaker or panelist in recent conferences.
+
+\paragraph{Diversifying participation:} The proposals could describe how the call-for-papers and outreach will encourage people from marginalized groups to at- tend and submit to the workshop, e.g. providing mentoring, subsidies, coordinating with affinity groups, diversifying the selection of papers and so on.
+


### PR DESCRIPTION
The ACL workshop proposals follow a template that would be useful to make available here, so adding the current version of the template.